### PR TITLE
LPS-24178 - Tomcat warns of potential memory leak error due to unhalted threads on undeploying Solr-Web

### DIFF
--- a/webs/solr-web/docroot/WEB-INF/src/META-INF/solr-spring.xml
+++ b/webs/solr-web/docroot/WEB-INF/src/META-INF/solr-spring.xml
@@ -13,7 +13,7 @@
 	<!-- Solr search engine -->
 
 	<bean id="com.liferay.portal.search.solr.server.BasicAuthSolrServer" class="com.liferay.portal.search.solr.server.BasicAuthSolrServer">
-		<constructor-arg type="java.lang.String" value="http://localhost:8080/solr" />
+		<constructor-arg type="java.lang.String" value="http://localhost:8983/solr" />
 	</bean>
 	<bean id="com.liferay.portal.search.solr.server.LiveServerChecker" class="com.liferay.portal.search.solr.server.LiveServerChecker">
 		<constructor-arg>

--- a/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/server/BasicAuthSolrServer.java
+++ b/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/server/BasicAuthSolrServer.java
@@ -37,6 +37,8 @@ import org.apache.solr.common.util.NamedList;
  */
 public class BasicAuthSolrServer extends SolrServer {
 
+	private boolean shutdown;
+
 	public BasicAuthSolrServer(String url) throws MalformedURLException {
 		this(null, null, url);
 	}
@@ -96,7 +98,13 @@ public class BasicAuthSolrServer extends SolrServer {
 	public NamedList<Object> request(SolrRequest solrRequest)
 		throws IOException, SolrServerException {
 
-		return _server.request(solrRequest);
+		synchronized (this) {
+			if (shutdown == true) {
+				return null;
+			}
+
+			return _server.request(solrRequest);
+		}
 	}
 
 	public NamedList<Object> request(
@@ -147,6 +155,12 @@ public class BasicAuthSolrServer extends SolrServer {
 
 	public void setSoTimeout(int soTimeout) {
 		_server.setSoTimeout(soTimeout);
+	}
+
+	public void shutdown() {
+		synchronized (this) {
+			shutdown = true;
+		}
 	}
 
 	private String _password;

--- a/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/server/SolrServerFactoryImpl.java
+++ b/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/server/SolrServerFactoryImpl.java
@@ -72,6 +72,10 @@ public class SolrServerFactoryImpl implements SolrServerFactory {
 				return;
 			}
 
+			BasicAuthSolrServer solrServer =
+				(BasicAuthSolrServer)solrServerWrapper.getServer();
+			solrServer.shutdown();
+
 			_deadServers.put(solrServerWrapper.getId(), solrServerWrapper);
 			_liveServers.remove(solrServerWrapper.getId());
 		}

--- a/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/servlet/SolrServletContextListener.java
+++ b/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/servlet/SolrServletContextListener.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.solr.servlet;
 import com.liferay.portal.kernel.concurrent.ConcurrentHashSet;
 import com.liferay.portal.kernel.util.BasePortalLifecycle;
 import com.liferay.portal.search.solr.server.LiveServerChecker;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 
 import java.util.Set;
 
@@ -50,6 +51,8 @@ public class SolrServletContextListener
 
 			_liveServerCheckers.remove(liveServerChecker);
 		}
+
+		MultiThreadedHttpConnectionManager.shutdownAll();
 	}
 
 	@Override


### PR DESCRIPTION
Hi Ray,
I am sending to you a one pull request regarding to this issue.

The main cause of the problem is in MultiThreadedHttpConnectionManager class. It starts ReferenceQueueThread thread and this thread is killed only when you call MultiThreadedHttpConnectionManager.shutdownAll method(I call it in SolrServletContextListener.doPortalDestroy method). Otherwise you will get a message mentioned in the issue.

I have also changed default port for solr(8983 instead of 8080).

Also because of multithreading environment I have put some shutdown processing in BasicAuthSolrServer class, because otherwise some exceptions appear randomly.

Best Regards  
