### PR TITLE
SOS-1015 Fix Source Format

### DIFF
--- a/portlets/tasks-portlet/docroot/init.jsp
+++ b/portlets/tasks-portlet/docroot/init.jsp
@@ -85,6 +85,8 @@ page import="javax.portlet.WindowState" %>
 <liferay-theme:defineObjects />
 
 <%
+themeDisplay.setIncludeServiceJs(true);
+
 String currentURL = PortalUtil.getCurrentURL(request);
 
 Group group = themeDisplay.getScopeGroup();

--- a/portlets/tasks-portlet/docroot/tasks/edit_task.jsp
+++ b/portlets/tasks-portlet/docroot/tasks/edit_task.jsp
@@ -17,8 +17,6 @@
 <%@ include file="/init.jsp" %>
 
 <%
-themeDisplay.setIncludeServiceJs(true);
-
 long tasksEntryId = ParamUtil.getLong(request, "tasksEntryId");
 
 TasksEntry tasksEntry = null;


### PR DESCRIPTION
Hi Jon,

We need to include the code "themeDisplay.setIncludeServiceJs(true);" in the init.jsp, because if we put this in the edit_task.jsp  when we open the dialog this doesn't loaded the file "service.js".

This is because when the A.Dialog rendered with a "windowstate Exclusive" this never include the top_js.jspf, this only is loaded when the portlet is rendered. So we need to include this file when we load the portlet.

Regards,

Eudaldo.
