### PR TITLE
LPS-29085

### DIFF
--- a/build-common-plugin.xml
+++ b/build-common-plugin.xml
@@ -152,6 +152,17 @@
 		</path>
 
 		<if>
+			<equals arg1="${java.classpath.jar}" arg2="true" trim="true" />
+			<then>
+				<classpath-to-jar classpathref="service.classpath" jar="build-service-classpath.jar" />
+
+				<path id="service.classpath">
+					<fileset file="build-service-classpath.jar" />
+				</path>
+			</then>
+		</if>
+
+		<if>
 			<not>
 				<isset property="service.input.file" />
 			</not>
@@ -166,6 +177,7 @@
 			fork="true"
 			newenvironment="true"
 			outputproperty="service.test.output"
+			errorproperty="service.error.output"
 		>
 			<jvmarg value="-Xms512m" />
 			<jvmarg value="-Xmx1024m" />
@@ -200,6 +212,7 @@
 		</java>
 
 		<echo>${service.test.output}</echo>
+		<echo>${service.error.output}</echo>
 
 		<if>
 			<contains string="${service.test.output}" substring="Error" />
@@ -208,7 +221,25 @@
 			</then>
 		</if>
 
+		<if>
+			<contains string="${service.error.output}" substring="CreateProcess" />
+			<then>
+				<fail>
+					Service Builder failed due to classpath length is too long for OS. 
+					Please add "java.classpath.jar=true" in build.${user.name}.properties file
+					to enable a workaround for this problem.
+				</fail>
+			</then>
+		</if>
+
 		<delete file="ServiceBuilder.temp" />
+
+		<if>
+			<equals arg1="${java.classpath.jar}" arg2="true" trim="true" />
+			<then>
+				<delete file="build-service-classpath.jar" />
+			</then>
+		</if>
 
 		<mkdir dir="docroot/WEB-INF/service-classes" />
 
@@ -241,6 +272,17 @@
 			<pathelement location="docroot/WEB-INF/classes" />
 		</path>
 
+		<if>
+			<equals arg1="${java.classpath.jar}" arg2="true" trim="true" />
+			<then>
+				<classpath-to-jar classpathref="wsdd.classpath" jar="build-wsdd-classpath.jar" />
+
+				<path id="wsdd.classpath">
+					<fileset file="build-wsdd-classpath.jar" />
+				</path>
+			</then>			
+		</if>
+
 		<java
 			classname="com.liferay.portal.tools.WSDDBuilder"
 			classpathref="wsdd.classpath"
@@ -255,6 +297,13 @@
 			<arg value="wsdd.service.namespace=Plugin" />
 			<arg value="wsdd.output.path=docroot/WEB-INF/src/" />
 		</java>
+
+		<if>
+			<equals arg1="${java.classpath.jar}" arg2="true" trim="true" />
+			<then>
+				<delete file="build-wsdd-classpath.jar" />
+			</then>
+		</if>
 	</target>
 
 	<target name="build-wsdl">
@@ -352,6 +401,27 @@
 
 		<delete dir="${tstamp.value}" />
 	</target>
+
+	<macrodef name="classpath-to-jar">
+		<attribute name="classpathref"/>
+		<attribute name="jar"/>
+
+		<sequential>
+			<manifestclasspath property="manifest.cp" jarfile="@{jar}" maxParentLevels="99">
+				<classpath refid="@{classpathref}"/>
+			</manifestclasspath>
+
+			<manifest file="@{jar}.manifest">
+				<attribute name="Class-Path" value="${manifest.cp}"/>
+			</manifest>
+
+			<jar destfile="@{jar}" manifest="@{jar}.manifest"/>
+
+			<delete file="@{jar}.manifest"/>
+
+			<var name="manifest.cp" unset="true"/>
+		</sequential>
+	</macrodef>
 
 	<target name="clean" description="clean">
 		<delete dir="docroot/WEB-INF/classes" />

--- a/build.properties
+++ b/build.properties
@@ -127,6 +127,14 @@
     ant.build.javac.source=1.5
     ant.build.javac.target=1.5
 
+    #
+    # When classpath gets too long, composing commands that reference it can
+    # exceed the 32k character limit of Windows CreateProcess function.
+    # Setting this to true will get around this problem by converting classpath
+    # into a jar whose manifest references all of the original classpath entries.
+    #
+    java.classpath.jar=false
+
     #javac.compiler=modern
     javac.compiler=org.eclipse.jdt.core.JDTCompilerAdapter
 


### PR DESCRIPTION
Added a java.classpath.jar option that will re-write the path with jar workaround if the property is set to true.  However, the code to detect errors doesn't seem to be working.  Because the values of the error output property (along with the normal output property) are always empty when they are evaluated.  The echo always just shows

```
 [echo] ${service.test.output}
 [echo] ${service.error.output}
```
