### PR TITLE
LPS35675 - As a portal administrator I should be able to define rules for mobile devices based on device's physical display size and screen resolution.

### DIFF
--- a/webs/wurfl-web/docroot/WEB-INF/src/com/liferay/portal/mobile/device/wurfl/WURFLConstants.java
+++ b/webs/wurfl-web/docroot/WEB-INF/src/com/liferay/portal/mobile/device/wurfl/WURFLConstants.java
@@ -28,6 +28,8 @@ public class WURFLConstants {
 	public static final String DISPLAY_HEIGHT = "physical_screen_height";
 
 	public static final String DISPLAY_WIDTH = "physical_screen_width";
+	
+	public static final String DUAL_ORIENTATION = "dual_orientation";
 
 	public static final String HAS_QWERTY_KEYBOARD = "has_qwerty_keyboard";
 

--- a/webs/wurfl-web/docroot/WEB-INF/src/com/liferay/portal/mobile/device/wurfl/WURFLDevice.java
+++ b/webs/wurfl-web/docroot/WEB-INF/src/com/liferay/portal/mobile/device/wurfl/WURFLDevice.java
@@ -50,26 +50,31 @@ public class WURFLDevice extends AbstractDevice {
 
 	@Override
 	public String getBrand() {
+
 		return getValue(WURFLConstants.BRAND_NAME);
 	}
 
 	@Override
 	public String getBrowser() {
+
 		return getValue(WURFLConstants.MOBILE_BROWSER);
 	}
 
 	@Override
 	public String getBrowserVersion() {
+
 		return getValue(WURFLConstants.MOBILE_BROWSER_VERSION);
 	}
 
 	@Override
 	public Map<String, Capability> getCapabilities() {
+
 		return _capabilities;
 	}
 
 	@Override
 	public String getCapability(String name) {
+
 		Capability capability = _capabilities.get(name);
 
 		if (capability == null) {
@@ -81,37 +86,31 @@ public class WURFLDevice extends AbstractDevice {
 
 	@Override
 	public Dimensions getDisplaySize() {
-		Capability heightCapability = _capabilities.get(
-			WURFLConstants.DISPLAY_HEIGHT);
-		Capability widthCapability = _capabilities.get(
-			WURFLConstants.DISPLAY_WIDTH);
 
-		if ((heightCapability == null) || (widthCapability == null)) {
-			return Dimensions.UNKNOWN;
-		}
-
-		int height = GetterUtil.getInteger(heightCapability.getValue());
-		int width = GetterUtil.getInteger(widthCapability.getValue());
-
-		return new Dimensions(height, width);
+		return getDimensions(
+			WURFLConstants.DISPLAY_HEIGHT, WURFLConstants.DISPLAY_WIDTH);
 	}
 
 	public String getModel() {
+
 		return getValue(WURFLConstants.MODEL_NAME);
 	}
 
 	@Override
 	public String getOS() {
+
 		return getValue(WURFLConstants.DEVICE_OS);
 	}
 
 	@Override
 	public String getOSVersion() {
+
 		return getValue(WURFLConstants.DEVICE_OS_VERSION);
 	}
 
 	@Override
 	public String getPointingMethod() {
+
 		return getValue(WURFLConstants.POINTING_METHOD);
 	}
 
@@ -121,40 +120,38 @@ public class WURFLDevice extends AbstractDevice {
 	@Deprecated
 	@Override
 	public Dimensions getScreenSize() {
+
 		return getResolution();
 	}
 
+	@Override
 	public Dimensions getResolution() {
-		Capability heightCapability = _capabilities.get(
-			WURFLConstants.RESOLUTION_HEIGHT);
-		Capability widthCapability = _capabilities.get(
-			WURFLConstants.RESOLUTION_WIDTH);
 
-		if ((heightCapability == null) || (widthCapability == null)) {
-			return Dimensions.UNKNOWN;
-		}
-
-		int height = GetterUtil.getInteger(heightCapability.getValue());
-		int width = GetterUtil.getInteger(widthCapability.getValue());
-
-		return new Dimensions(height, width);
+		return getDimensions(
+			WURFLConstants.RESOLUTION_HEIGHT, WURFLConstants.RESOLUTION_WIDTH);
 	}
 
 	@Override
 	public boolean hasQwertyKeyboard() {
-		Capability capability = _capabilities.get(
-			WURFLConstants.HAS_QWERTY_KEYBOARD);
 
-		if (capability == null) {
-			return false;
-		}
-
-		return GetterUtil.getBoolean(capability.getValue(), false);
+		return getBoolean(WURFLConstants.HAS_QWERTY_KEYBOARD);
 	}
 
 	@Override
 	public boolean isTablet() {
-		Capability capability = _capabilities.get(WURFLConstants.IS_TABLET);
+
+		return getBoolean(WURFLConstants.IS_TABLET);
+	}
+
+	@Override
+	public boolean supportsDualOrientation() {
+
+		return getBoolean(WURFLConstants.DUAL_ORIENTATION);
+	}
+
+	protected boolean getBoolean(String name) {
+
+		Capability capability = _capabilities.get(name);
 
 		if (capability == null) {
 			return false;
@@ -163,7 +160,29 @@ public class WURFLDevice extends AbstractDevice {
 		return GetterUtil.getBoolean(capability.getValue(), false);
 	}
 
+	protected Dimensions getDimensions(
+		String heightCapability, String widthCapability) {
+
+		Capability h = _capabilities.get(heightCapability);
+		Capability w = _capabilities.get(widthCapability);
+
+		if ((h == null) || (w == null)) {
+			return Dimensions.UNKNOWN;
+		}
+
+		int height = GetterUtil.getInteger(h.getValue());
+		int width = GetterUtil.getInteger(w.getValue());
+
+		if (supportsDualOrientation() && height < width) {
+			return new Dimensions(width, height);
+		}
+		else {
+			return new Dimensions(height, width);
+		}
+	}
+
 	protected String getValue(String name) {
+
 		Capability capability = _capabilities.get(name);
 
 		if (capability == null) {

--- a/webs/wurfl-web/docroot/WEB-INF/src/com/liferay/portal/mobile/device/wurfl/WURFLKnownDevices.java
+++ b/webs/wurfl-web/docroot/WEB-INF/src/com/liferay/portal/mobile/device/wurfl/WURFLKnownDevices.java
@@ -42,6 +42,7 @@ public class WURFLKnownDevices implements KnownDevices {
 
 	@Override
 	public Set<VersionableName> getBrands() {
+
 		if (!_initialized) {
 			NoKnownDevices noKnownDevices = NoKnownDevices.getInstance();
 
@@ -53,6 +54,7 @@ public class WURFLKnownDevices implements KnownDevices {
 
 	@Override
 	public Set<VersionableName> getBrowsers() {
+
 		if (!_initialized) {
 			NoKnownDevices noKnownDevices = NoKnownDevices.getInstance();
 
@@ -64,11 +66,13 @@ public class WURFLKnownDevices implements KnownDevices {
 
 	@Override
 	public Map<Capability, Set<String>> getDeviceIds() {
+
 		return _devicesIds;
 	}
 
 	@Override
 	public Set<Dimensions> getDisplaySizes() {
+
 		if (!_initialized) {
 			NoKnownDevices noKnownDevices = NoKnownDevices.getInstance();
 
@@ -80,6 +84,7 @@ public class WURFLKnownDevices implements KnownDevices {
 
 	@Override
 	public Set<VersionableName> getOperatingSystems() {
+
 		if (!_initialized) {
 			NoKnownDevices noKnownDevices = NoKnownDevices.getInstance();
 
@@ -91,6 +96,7 @@ public class WURFLKnownDevices implements KnownDevices {
 
 	@Override
 	public Set<String> getPointingMethods() {
+
 		if (!_initialized) {
 			NoKnownDevices noKnownDevices = NoKnownDevices.getInstance();
 
@@ -102,6 +108,7 @@ public class WURFLKnownDevices implements KnownDevices {
 
 	@Override
 	public Set<Dimensions> getScreenResolutions() {
+
 		if (!_initialized) {
 			NoKnownDevices noKnownDevices = NoKnownDevices.getInstance();
 
@@ -111,23 +118,26 @@ public class WURFLKnownDevices implements KnownDevices {
 		return _screenResolutins;
 	}
 
-	
 	public synchronized void initialize() {
+
 		loadWURFLDevices();
 	}
 
 	@Override
 	public synchronized void reload() {
+
 		_initialized = false;
 
 		loadWURFLDevices();
 	}
 
 	public void setWurflHolder(WURFLHolder wurflHolder) {
+
 		_wurflHolder = wurflHolder;
 	}
 
 	protected void loadWURFLDevices() {
+
 		if (_initialized) {
 			return;
 		}
@@ -158,7 +168,7 @@ public class WURFLKnownDevices implements KnownDevices {
 			new HashMap<String, VersionableName>();
 
 		for (Object deviceIdObject : wurflUtils.getAllDevicesId()) {
-			String deviceId = (String)deviceIdObject;
+			String deviceId = (String) deviceIdObject;
 
 			Device device = wurflUtils.getDeviceById(deviceId);
 
@@ -178,18 +188,20 @@ public class WURFLKnownDevices implements KnownDevices {
 				device, _pointingMethods, WURFLConstants.POINTING_METHOD);
 
 			updateCapability(
-				device, _displaySizes, WURFLConstants.DISPLAY_HEIGHT, WURFLConstants.DISPLAY_WIDTH);
+				device, _displaySizes, WURFLConstants.DISPLAY_HEIGHT,
+				WURFLConstants.DISPLAY_WIDTH);
 
 			updateCapability(
-				device, _screenResolutins, WURFLConstants.RESOLUTION_HEIGHT, WURFLConstants.RESOLUTION_WIDTH);
+				device, _screenResolutins, WURFLConstants.RESOLUTION_HEIGHT,
+				WURFLConstants.RESOLUTION_WIDTH);
 
 			updateDevicesIds(device, WURFLConstants.DEVICE_OS);
 		}
 
 		_brands = new TreeSet<VersionableName>(brands.values());
 		_browsers = new TreeSet<VersionableName>(browsers.values());
-		_operatingSystems = new TreeSet<VersionableName>(
-			operatingSystems.values());
+		_operatingSystems =
+			new TreeSet<VersionableName>(operatingSystems.values());
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Loaded database in " + stopWatch.getTime() + " ms");
@@ -209,17 +221,27 @@ public class WURFLKnownDevices implements KnownDevices {
 	}
 
 	protected void updateCapability(
-		Device device, Set<Dimensions> capabilityValues, String capabilityHeight, String capabilityWidth) {
+		Device device, Set<Dimensions> capabilityValues,
+		String capabilityHeight, String capabilityWidth) {
 
-		int heightValue = GetterUtil.getInteger(device.getCapability(capabilityHeight));
-		int widthValue = GetterUtil.getInteger(device.getCapability(capabilityWidth));
-		
+		int heightValue =
+			GetterUtil.getInteger(device.getCapability(capabilityHeight));
+		int widthValue =
+			GetterUtil.getInteger(device.getCapability(capabilityWidth));
+
 		if (heightValue > 0 && widthValue > 0) {
-			capabilityValues.add(new Dimensions(heightValue, widthValue));
+			if (GetterUtil.getBoolean(device.getCapability(WURFLConstants.DUAL_ORIENTATION)) &&
+				heightValue < widthValue) {
+				capabilityValues.add(new Dimensions(widthValue, heightValue));
+			}
+			else {
+				capabilityValues.add(new Dimensions(heightValue, widthValue));
+			}
 		}
 	}
 
 	protected void updateDevicesIds(Device device, String... capabilityNames) {
+
 		if ((capabilityNames == null) || (capabilityNames.length == 0)) {
 			return;
 		}
@@ -231,8 +253,8 @@ public class WURFLKnownDevices implements KnownDevices {
 				continue;
 			}
 
-			Capability capability = new Capability(
-				capabilityName, capabilityValue);
+			Capability capability =
+				new Capability(capabilityName, capabilityValue);
 
 			Set<String> deviceIds = _devicesIds.get(capability);
 
@@ -257,8 +279,8 @@ public class WURFLKnownDevices implements KnownDevices {
 			return;
 		}
 
-		VersionableName versionableCapability = capabilities.get(
-			capabilityValue);
+		VersionableName versionableCapability =
+			capabilities.get(capabilityValue);
 
 		if (versionableCapability == null) {
 			versionableCapability = new VersionableName(capabilityValue);
@@ -269,12 +291,12 @@ public class WURFLKnownDevices implements KnownDevices {
 		String capabilitySubversionValue = null;
 
 		if (Validator.isNotNull(capabilitySubversionAttributeName)) {
-			capabilitySubversionValue = device.getCapability(
-				capabilitySubversionAttributeName);
+			capabilitySubversionValue =
+				device.getCapability(capabilitySubversionAttributeName);
 		}
 
-		String capabilityVersionValue = device.getCapability(
-			capabilityVersionAttributeName);
+		String capabilityVersionValue =
+			device.getCapability(capabilityVersionAttributeName);
 
 		if (Validator.isNotNull(capabilityVersionValue)) {
 			if (Validator.isNotNull(capabilitySubversionValue)) {


### PR DESCRIPTION
Updated to use 'supportsDualOrientation' capability field for better support for screen size and resolution ranges.
