### PR TITLE
LPS-38008 Only .1 versions are copied for shared

### DIFF
--- a/build-common-plugin.xml
+++ b/build-common-plugin.xml
@@ -717,7 +717,7 @@ Please find a solution that does not require portal-impl.jar.
 
 								<for param="import.shared.full.path">
 									<path>
-										<fileset dir="${sdk.dir}/dist" includes="@{import.shared.current}-${lp.version}.1*.jar" />
+										<fileset dir="${sdk.dir}/dist" includes="@{import.shared.current}-${lp.version}*.jar" />
 									</path>
 									<sequential>
 										<copy


### PR DESCRIPTION
This is a quick fix for the release as we currently cannot build. It's very hard to get the proper file name of the current shared lib so we might want to re-think the naming later.

The root cause of the issue is this: http://issues.liferay.com/browse/LPS-38010

(However this fix is still needed)
