### PR TITLE
LPS-47374 Add content targeting to plugins includes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
 	<import file="build-common.xml" />
 
 	<path id="plugins.includes.path">
+		<dirset dir="apps/content-targeting" excludes="${plugins.excludes}" includes="${plugins.includes}" />
 		<dirset dir="hooks" excludes="${plugins.excludes}" includes="${plugins.includes}" />
 		<dirset dir="layouttpl" excludes="${plugins.excludes}" includes="${plugins.includes}" />
 		<dirset dir="portlets" excludes="${plugins.excludes}" includes="${plugins.includes}" />


### PR DESCRIPTION
Hey Brian,

Following your idea in brianchandotcom/liferay-plugins/pull/3301 we've added apps/content-targeting to the plugins.includes.path of the build.xml in the 6.2.x plugins SDK. 

Now if a developer adds the list of Content Targeting plugins to his build.<name>.properties file, they will be deployed.

Thanks

@juliocamarero
