### PR TITLE
LPS-48937

### DIFF
--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
@@ -178,12 +178,8 @@ public class AkismetEditPageAction extends BaseStrutsPortletAction {
 						wikiPage.getTitle(), previousVersion, serviceContext);
 				}
 				else {
-					WikiPageLocalServiceUtil.updatePage(
-						themeDisplay.getUserId(), wikiPage.getNodeId(),
-						wikiPage.getTitle(), latestVersion, null,
-						StringPool.BLANK, true, wikiPage.getFormat(),
-						wikiPage.getParentTitle(), wikiPage.getRedirectTitle(),
-						serviceContext);
+					wikiPage.setVersion(latestVersion);
+					WikiPageLocalServiceUtil.updateWikiPage(wikiPage);
 				}
 			}
 

--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
@@ -66,11 +66,6 @@ public class AkismetWikiPageLocalServiceImpl
 
 		boolean enabled = isWikiEnabled(userId, nodeId, serviceContext);
 
-		if (enabled) {
-			serviceContext.setWorkflowAction(
-				WorkflowConstants.ACTION_SAVE_DRAFT);
-		}
-
 		WikiPage page = super.addPage(
 			userId, nodeId, title, version, content, summary, minorEdit, format,
 			head, parentTitle, redirectTitle, serviceContext);
@@ -99,16 +94,8 @@ public class AkismetWikiPageLocalServiceImpl
 			page.setSummary(AkismetConstants.WIKI_PAGE_PENDING_APPROVAL);
 			page.setStatus(WorkflowConstants.STATUS_APPROVED);
 
-			page = super.updateWikiPage(page);
+			return super.updateWikiPage(page);
 
-			ServiceContext newServiceContext = new ServiceContext();
-
-			newServiceContext.setFormDate(page.getModifiedDate());
-
-			return super.updatePage(
-				userId, nodeId, title, page.getVersion(), null,
-				StringPool.BLANK, true, format, parentTitle, redirectTitle,
-				newServiceContext);
 		}
 		finally {
 			NotificationThreadLocal.setEnabled(notificationEnabled);
@@ -132,11 +119,6 @@ public class AkismetWikiPageLocalServiceImpl
 		}
 
 		boolean enabled = isWikiEnabled(userId, nodeId, serviceContext);
-
-		if (enabled) {
-			serviceContext.setWorkflowAction(
-				WorkflowConstants.ACTION_SAVE_DRAFT);
-		}
 
 		WikiPage page = super.updatePage(
 			userId, nodeId, title, version, content, summary, minorEdit, format,
@@ -181,10 +163,7 @@ public class AkismetWikiPageLocalServiceImpl
 					newServiceContext);
 			}
 			else {
-				return super.updatePage(
-					userId, nodeId, title, page.getVersion(), null,
-					StringPool.BLANK, true, format, parentTitle, redirectTitle,
-					newServiceContext);
+				return page;
 			}
 		}
 		finally {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-48297

The method of updatePage() in WikiPagelocalServiceUtilImpl.java will return a new page whose version is one larger than the old page's.

However, in my view, the version of page should not be added when it is just marked as spam or not spam without reverting to its old version. So, I removed that method. Now the content can been seen after created by a user and its version is not changed after markings.

I also deleted  lines 69-73 and 136-140  because I cannot see why the workflow action is save draft, which leads that the page cannot be displayed correctly after edition when it is a spam.
