### PR TITLE
New CDI scope @PortletSessionScoped that binds bean to the PortletSession

### DIFF
--- a/shared/cdi-portlet-bridge-shared/src/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/shared/cdi-portlet-bridge-shared/src/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+com.liferay.cdi.portlet.bridge.CDIExtension

--- a/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/CDIExtension.java
+++ b/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/CDIExtension.java
@@ -1,0 +1,22 @@
+package com.liferay.cdi.portlet.bridge;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+import com.liferay.cdi.portlet.bridge.context.PortletSessionScoped;
+
+/**
+ * CDI entry point for registering the {@link PortletSessionScoped} scope and the according {@link PortletSessionContext}.
+ */
+public class CDIExtension implements Extension {
+    
+    public void addScope(@Observes final BeforeBeanDiscovery event) {
+        event.addScope(PortletSessionScoped.class, true, true);
+    }
+
+    public void registerContext(@Observes final AfterBeanDiscovery event) {
+        event.addContext(new CDIPortletSessionContext());
+    }
+}

--- a/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/CDIPortletFilter.java
+++ b/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/CDIPortletFilter.java
@@ -57,7 +57,12 @@ public class CDIPortletFilter
 		actionResponse = cdiResponseFactory.getCDIActionResponse(
 			actionResponse, actionRequest.getLocale());
 
-		filterChain.doFilter(actionRequest, actionResponse);
+        PortletRequestContainer.registerPortletRequest(actionRequest);
+        try {
+            filterChain.doFilter(actionRequest, actionResponse);
+        } finally {
+            PortletRequestContainer.unregisterPortletRequest();
+        }
 	}
 
 	@Override
@@ -75,7 +80,12 @@ public class CDIPortletFilter
 		eventResponse = cdiResponseFactory.getCDIEventResponse(
 			eventResponse, eventRequest.getLocale());
 
-		filterChain.doFilter(eventRequest, eventResponse);
+        PortletRequestContainer.registerPortletRequest(eventRequest);
+        try {
+            filterChain.doFilter(eventRequest, eventResponse);
+        } finally {
+            PortletRequestContainer.unregisterPortletRequest();
+        }
 	}
 
 	@Override
@@ -93,7 +103,12 @@ public class CDIPortletFilter
 		renderResponse = cdiResponseFactory.getCDIRenderResponse(
 			renderResponse, renderRequest.getLocale());
 
-		filterChain.doFilter(renderRequest, renderResponse);
+        PortletRequestContainer.registerPortletRequest(renderRequest);
+        try {
+            filterChain.doFilter(renderRequest, renderResponse);
+        } finally {
+            PortletRequestContainer.unregisterPortletRequest();
+        }
 	}
 
 	@Override
@@ -112,7 +127,12 @@ public class CDIPortletFilter
 		resourceResponse = cdiResponseFactory.getCDIResourceResponse(
 			resourceResponse, resourceRequest.getLocale());
 
-		filterChain.doFilter(resourceRequest, resourceResponse);
+        PortletRequestContainer.registerPortletRequest(resourceRequest);
+        try {
+            filterChain.doFilter(resourceRequest, resourceResponse);
+        } finally {
+            PortletRequestContainer.unregisterPortletRequest();
+        }
 	}
 
 	@Override

--- a/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/CDIPortletSessionContext.java
+++ b/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/CDIPortletSessionContext.java
@@ -1,0 +1,71 @@
+package com.liferay.cdi.portlet.bridge;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.portlet.PortletSession;
+
+import com.liferay.cdi.portlet.bridge.context.PortletSessionScoped;
+
+/**
+ * A simple {@link Context} implementation that stores CDI beans within the {@link PortletSession}.
+ * 
+ * @author Michael Scholz
+ */
+public class CDIPortletSessionContext implements Context, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private static final String ATTRIBUTE_PREFIX = CDIPortletSessionContext.class.getName();
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return PortletSessionScoped.class;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(final Contextual<T> contextual, final CreationalContext<T> creationalContext) {
+        if(!(contextual instanceof Bean<?>)) {
+            return null;
+        }
+
+        final String attributeName = getAttributeName(contextual);
+
+        final PortletSession portletSession = PortletRequestContainer.getCurrentPortletRequest().getPortletSession(true);
+
+        T result = (T) portletSession.getAttribute(attributeName);
+        if(result == null) {
+            result = contextual.create(creationalContext);
+            portletSession.setAttribute(attributeName, result);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(final Contextual<T> contextual) {
+        if(!(contextual instanceof Bean<?>)) {
+            return null;
+        }
+
+        final PortletSession portletSession = PortletRequestContainer.getCurrentPortletRequest().getPortletSession();
+        return portletSession != null ? (T) portletSession.getAttribute(getAttributeName(contextual)) : null;
+    }
+
+    @Override
+    public boolean isActive() {
+        return PortletRequestContainer.getCurrentPortletRequest() != null;
+    }
+
+    private static <T> String getAttributeName(final Contextual<T> contextual) {
+        final Bean<T> bean = (Bean<T>) contextual;
+        final String beanClassName = bean.getBeanClass().getName();
+
+        return ATTRIBUTE_PREFIX + "$" + beanClassName;
+    }
+}

--- a/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/PortletRequestContainer.java
+++ b/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/PortletRequestContainer.java
@@ -1,0 +1,20 @@
+package com.liferay.cdi.portlet.bridge;
+
+import javax.portlet.PortletRequest;
+
+class PortletRequestContainer {
+    
+    private static ThreadLocal<PortletRequest> currentPortletRequest = new ThreadLocal<PortletRequest>();
+
+    static void registerPortletRequest(final PortletRequest request) {
+        currentPortletRequest.set(request);
+    }
+    
+    static void unregisterPortletRequest() {
+        currentPortletRequest.set(null);
+    }
+    
+    static PortletRequest getCurrentPortletRequest() {
+        return currentPortletRequest.get();
+    }
+}

--- a/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/context/PortletSessionScoped.java
+++ b/shared/cdi-portlet-bridge-shared/src/com/liferay/cdi/portlet/bridge/context/PortletSessionScoped.java
@@ -1,0 +1,24 @@
+package com.liferay.cdi.portlet.bridge.context;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.context.NormalScope;
+import javax.portlet.PortletSession;
+
+/**
+ * A custom CDI Scope that is bound to the {@link PortletSession}.
+ *  
+ * @author Michael Scholz
+ */
+@Target(value = { METHOD, FIELD, TYPE })
+@Retention(RUNTIME)
+@NormalScope(passivating = true)
+@Inherited
+public @interface PortletSessionScoped {}


### PR DESCRIPTION
This is a code proposal related to the following discussion thread: https://www.liferay.com/de/community/forums/-/message_boards/view_message/40442240

I could not really test the code because I wasn't able to set up the whole build stuff on my local PC.

But I tested it within an extra Project - it worked well.
