### PR TITLE
Update view_article.jsp

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/admin/common/view_article.jsp
+++ b/portlets/knowledge-base-portlet/docroot/admin/common/view_article.jsp
@@ -19,7 +19,7 @@
 <%
 KBArticle kbArticle = (KBArticle)request.getAttribute(WebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
-if (enableKBArticleViewCountIncrement && !kbArticle.isDraft()) {
+if (enableKBArticleViewCountIncrement && !kbArticle.isDraft() && !kbArticle.isPending()) {
 	KBArticle latestKBArticle = KBArticleLocalServiceUtil.getLatestKBArticle(kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
 
 	KBArticleLocalServiceUtil.updateViewCount(themeDisplay.getUserId(), kbArticle.getResourcePrimKey(), latestKBArticle.getViewCount() + 1);


### PR DESCRIPTION
Added !kbArticle.isPending() as condition.
Earlier code executes when the status is not in draft status, i.e. also executes in case of pending status, and gives an exception from 
	KBArticle latestKBArticle = KBArticleLocalServiceUtil.getLatestKBArticle(kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
 as this code fetch the data if article is approved, so restricting this code to be executed if status is pending.