### PR TITLE
LPS-54241 Fixes in FileSystemImporter

### DIFF
--- a/webs/resources-importer-web/docroot/WEB-INF/src/com/liferay/resourcesimporter/util/FileSystemImporter.java
+++ b/webs/resources-importer-web/docroot/WEB-INF/src/com/liferay/resourcesimporter/util/FileSystemImporter.java
@@ -136,6 +136,7 @@ public class FileSystemImporter extends BaseImporter {
 		throws PortalException, SystemException {
 
 		String fileName = FileUtil.stripExtension(file.getName());
+		String language = getDDMTemplateLanguage(file.getName());
 
 		String name = getName(fileName);
 
@@ -164,7 +165,7 @@ public class FileSystemImporter extends BaseImporter {
 					userId, groupId, classNameId, 0, getKey(fileName),
 					getMap(name), null,
 					DDMTemplateConstants.TEMPLATE_TYPE_DISPLAY,
-					StringPool.BLANK, getDDMTemplateLanguage(name), script,
+					StringPool.BLANK, language, script,
 					false, false, StringPool.BLANK, null, serviceContext);
 			}
 			else {
@@ -172,7 +173,7 @@ public class FileSystemImporter extends BaseImporter {
 					ddmTemplate.getTemplateId(), ddmTemplate.getClassPK(),
 					getMap(name), null,
 					DDMTemplateConstants.TEMPLATE_TYPE_DISPLAY,
-					StringPool.BLANK, getDDMTemplateLanguage(name), script,
+					StringPool.BLANK, language, script,
 					false, false, StringPool.BLANK, null, serviceContext);
 			}
 		}
@@ -574,6 +575,8 @@ public class FileSystemImporter extends BaseImporter {
 			String ddmStructureKey, String fileName, InputStream inputStream)
 		throws Exception {
 
+		String language = getDDMTemplateLanguage(fileName);
+
 		fileName = FileUtil.stripExtension(fileName);
 
 		String name = getName(fileName);
@@ -614,7 +617,7 @@ public class FileSystemImporter extends BaseImporter {
 					ddmStructure.getStructureId(), getKey(fileName),
 					getMap(name), null,
 					DDMTemplateConstants.TEMPLATE_TYPE_DISPLAY, null,
-					getDDMTemplateLanguage(fileName), replaceFileEntryURL(xsl),
+					language, replaceFileEntryURL(xsl),
 					false, false, null, null, serviceContext);
 			}
 			else {
@@ -622,7 +625,7 @@ public class FileSystemImporter extends BaseImporter {
 					ddmTemplate.getTemplateId(),
 					PortalUtil.getClassNameId(DDMStructure.class), getMap(name),
 					null, DDMTemplateConstants.TEMPLATE_TYPE_DISPLAY, null,
-					getDDMTemplateLanguage(fileName), replaceFileEntryURL(xsl),
+					language, replaceFileEntryURL(xsl),
 					false, false, null, null, serviceContext);
 			}
 		}


### PR DESCRIPTION
In FileSystemImporter the method getDDMTemplateLanguage() is called to
determine what template language to set, but before the method is
called, the file extension is stripped off of the filename, so it always
defaults to Velocity (.vm)