### PR TITLE
Use a variable lp.dependencies.version in build.properties for gradle build

### DIFF
--- a/ant-properties.gradle
+++ b/ant-properties.gradle
@@ -1,0 +1,19 @@
+def loadProperties = {
+	Properties properties, String fileName ->
+
+	File file = file(fileName)
+
+	if (file.exists()) {
+		properties.load(new FileInputStream(file))
+	}
+}
+
+Properties antProperties = new Properties()
+
+loadProperties(antProperties, "${rootDir}/build.properties")
+loadProperties(antProperties, "${rootDir}/build." + System.properties["user.name"] + ".properties")
+loadProperties(antProperties, "${rootDir}/build." + System.properties["COMPUTERNAME"] + ".properties")
+loadProperties(antProperties, "${rootDir}/build." + System.properties["HOST"] + ".properties")
+loadProperties(antProperties, "${rootDir}/build." + System.properties["HOSTNAME"] + ".properties")
+
+ext.antProperties = antProperties

--- a/build-plugins.gradle
+++ b/build-plugins.gradle
@@ -1,12 +1,15 @@
+
+
 import com.liferay.portal.kernel.util.ReleaseInfo
 
 import org.gradle.api.internal.file.copy.CopySpecResolver
+
 
 apply plugin: "war"
 
 buildscript {
 	dependencies {
-		classpath group: "com.liferay.portal", name: "portal-service", version: "7.0.0-SNAPSHOT"
+		classpath group: "com.liferay.portal", name: "portal-service", version: "${lfrDepVersion}"
 	}
 
 	repositories {
@@ -53,17 +56,17 @@ dependencies {
 	)
 
 	pluginRequiredLibraries(
-		[group: "com.liferay.portal", name: "util-bridges", version: "7.0.0-SNAPSHOT"],
-		[group: "com.liferay.portal", name: "util-java", version: "7.0.0-SNAPSHOT"],
-		[group: "com.liferay.portal", name: "util-taglib", version: "7.0.0-SNAPSHOT"],
+		[group: "com.liferay.portal", name: "util-bridges", version: "${lfrDepVersion}"],
+		[group: "com.liferay.portal", name: "util-java", version: "${lfrDepVersion}"],
+		[group: "com.liferay.portal", name: "util-taglib", version: "${lfrDepVersion}"],
 		[group: "commons-logging", name: "commons-logging", version: "1.1.1"],
 		[group: "log4j", name: "log4j", version: "1.2.16"]
 	)
 
 	portalTools(
-		[group: "com.liferay.portal", name: "portal-impl", version: "7.0.0-SNAPSHOT"],
-		[group: "com.liferay.portal", name: "portal-service", version: "7.0.0-SNAPSHOT"],
-		[group: "com.liferay.portal", name: "util-java", version: "7.0.0-SNAPSHOT"],
+		[group: "com.liferay.portal", name: "portal-impl", version: "${lfrDepVersion}"],
+		[group: "com.liferay.portal", name: "portal-service", version: "${lfrDepVersion}"],
+		[group: "com.liferay.portal", name: "util-java", version: "${lfrDepVersion}"],
 		[group: "com.thoughtworks.xstream", name: "xstream", version: "1.4.3"],
 		[group: "commons-configuration", name: "commons-configuration", version: "1.6"],
 		[group: "commons-lang", name: "commons-lang", version: "2.6"],
@@ -92,11 +95,11 @@ dependencies {
 		[group: "xerces", name: "xercesImpl", version: "2.11.0"]
 	)
 
-	portalWeb group: "com.liferay.portal", name: "portal-web", version: "7.0.0-SNAPSHOT"
+	portalWeb group: "com.liferay.portal", name: "portal-web", version: "${lfrDepVersion}"
 
 	providedCompile(
 		[group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"],
-		[group: "com.liferay.portal", name: "portal-service", version: "7.0.0-SNAPSHOT"],
+		[group: "com.liferay.portal", name: "portal-service", version: "${lfrDepVersion}"],
 		[group: "hsqldb", name: "hsqldb", version: "1.8.0.7"],
 		[group: "javax.activation", name: "activation", version: "1.1"],
 		[group: "javax.ccpp", name: "ccpp", version: "1.0"],

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ pluginProjects = {
 			return file
 		}()
 	}
-
+	
 	apply from: "${gradle.lfrSdkDir}/build-plugins.gradle"
 
 	if (name.endsWith("-theme")) {

--- a/build.properties
+++ b/build.properties
@@ -548,3 +548,4 @@
     #
     lp.version=7.0.0
     lp.version.file.suffix=
+    lp.dependencies.version=7.0.0-SNAPSHOT

--- a/portlets/chat-portlet/build.gradle
+++ b/portlets/chat-portlet/build.gradle
@@ -7,6 +7,6 @@ dependencies {
 		[group: "javax.servlet.jsp.jstl", name: "jstl-api", version: "1.2"],
 		[group: "org.glassfish.web", name: "jstl-impl", version: "1.2"],
 		[group: "org.slf4j", name: "slf4j-api", version: "1.7.2"],
-		[group: "com.liferay.portal", name: "util-slf4j", version: "7.0.0-SNAPSHOT"]
+		[group: "com.liferay.portal", name: "util-slf4j", version: "${lfrDepVersion}"]
 	)
 }

--- a/sdk.gradle
+++ b/sdk.gradle
@@ -21,7 +21,7 @@ configurations {
 }
 
 dependencies {
-	portalTaglib group: "com.liferay.portal", name: "util-taglib", version: "7.0.0-SNAPSHOT"
+	portalTaglib group: "com.liferay.portal", name: "util-taglib", version: "${ext.lfrDepVersion}"
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,20 +1,4 @@
-def loadProperties = {
-	Properties properties, String fileName ->
-
-	File file = file(fileName)
-
-	if (file.exists()) {
-		properties.load(new FileInputStream(file))
-	}
-}
-
-Properties antProperties = new Properties()
-
-loadProperties(antProperties, "build.properties")
-loadProperties(antProperties, "build." + System.properties["user.name"] + ".properties")
-loadProperties(antProperties, "build." + System.properties["COMPUTERNAME"] + ".properties")
-loadProperties(antProperties, "build." + System.properties["HOST"] + ".properties")
-loadProperties(antProperties, "build." + System.properties["HOSTNAME"] + ".properties")
+apply from: "./ant-properties.gradle"
 
 if (!hasProperty("lfrPluginsExcludes")) {
 	ext.lfrPluginsExcludes = antProperties["plugins.excludes"]
@@ -36,7 +20,7 @@ FileTree fileTree = fileTree(rootDir) {
 				"**/" + it + "/build.gradle"
 			}
 		)
- 
+
 		lfrPluginsIncludesArray.each(
 			{
 				include(it)
@@ -46,7 +30,7 @@ FileTree fileTree = fileTree(rootDir) {
 	else {
 		include("**/build.gradle")
 	}
- 
+
 	if ((lfrPluginsExcludes != "") && (lfrPluginsExcludes != "*")) {
 		lfrPluginsExcludes = lfrPluginsExcludes.replaceAll(" ", "")
 		lfrPluginsExcludes = lfrPluginsExcludes.replaceAll(",+", ",")
@@ -58,7 +42,7 @@ FileTree fileTree = fileTree(rootDir) {
 				"**/" + it + "/build.gradle"
 			}
 		)
- 
+
 		lfrPluginsExcludesArray.each(
 			{
 				exclude(it)
@@ -92,3 +76,4 @@ fileTree.each(
 include(":shared:portal-compat-shared")
 
 gradle.ext.lfrSdkDir = file(".")
+gradle.ext.lfrDepVersion =  antProperties["lp.dependencies.version"]

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,3 +1,8 @@
+apply from: "${gradle.lfrSdkDir}/ant-properties.gradle"
+
+if (!hasProperty("lfrDepVersion")) {
+	ext.lfrDepVersion = antProperties["lp.dependencies.version"]
+}
 Map<String, Map<String, String>> portalDependencies = [
 	antlr2: [
 		group: "antlr",
@@ -197,7 +202,7 @@ Map<String, Map<String, String>> portalDependencies = [
 	utilSlf4j: [
 		group: "com.liferay.portal",
 		name: "util-slf4j",
-		version: "7.0.0-SNAPSHOT"
+		version: "${lfrDepVersion}"
 	],
 	wsdl4j: [
 		group: "wsdl4j",


### PR DESCRIPTION
Use a variable lp.dependencies.version in build.properties to set liferay dependencies version in gradle build workflow instead hardcoding 7.0.0-SNAPSHOT (also in the currently released Plugins SDK 6.2.3)
With this variable you can release different version of Plugin SDK that build with gradle and the right liferay dependencies
