### PR TITLE
Fix Buddy comparator in chat

### DIFF
--- a/portlets/chat-portlet/docroot/WEB-INF/service/com/liferay/chat/util/comparator/BuddyComparator.java
+++ b/portlets/chat-portlet/docroot/WEB-INF/service/com/liferay/chat/util/comparator/BuddyComparator.java
@@ -33,13 +33,19 @@ public class BuddyComparator implements Comparator<Object[]> {
 
 	@Override
 	public int compare(Object[] buddy1, Object[] buddy2) {
-		long userId1 = (Long)buddy1[0];
+		long userId1 = 0;
+		if(buddy1[0] instanceof (Long)) {
+			userId1 = (Long) buddy1[0];
+		}
 		String firstName1 = (String)buddy1[2];
 		String middleName1 = (String)buddy1[3];
 		String lastName1 = (String)buddy1[4];
 		boolean awake1 = (Boolean)buddy1[6];
 
-		long userId2 = (Long)buddy2[0];
+		long userId2 = 0;
+		if(buddy2[0] instanceof Long) {
+			userId2 = (Long)buddy2[0];
+		}
 		String firstName2 = (String)buddy2[2];
 		String middleName2 = (String)buddy2[3];
 		String lastName2 = (String)buddy2[4];


### PR DESCRIPTION
There are cases where JabberImpl use comparator to search and sort but assigned true to first index and not an id resulting in a stacktrace:

The change will check the type of buddy[0] before assuming it is a Long
```
java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.Long
        at com.liferay.chat.util.comparator.BuddyComparator.compare(BuddyComparator.java:36)
        at com.liferay.chat.util.comparator.BuddyComparator.compare(BuddyComparator.java:1)
        at java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
        at java.util.TimSort.sort(TimSort.java:220)
        at java.util.Arrays.sort(Arrays.java:1512)
        at java.util.ArrayList.sort(ArrayList.java:1454)
        at java.util.Collections.sort(Collections.java:175)
        at com.liferay.chat.jabber.JabberImpl.getStatuses(JabberImpl.java:170)
        at com.liferay.chat.jabber.JabberUtil.getStatuses(JabberUtil.java:49)
        at com.liferay.chat.util.DefaultBuddyFinderImpl.getBuddies(DefaultBuddyFinderImpl.java:101)
        at com.liferay.chat.util.BuddyFinderUtil.getBuddies(BuddyFinderUtil.java:30)
        at com.liferay.chat.poller.ChatPollerProcessor.getBuddies(ChatPollerProcessor.java:78)
```